### PR TITLE
Add --prefix flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dirt-r-ee"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Cal Courtney <calthejuggler@gmail.com>"]
 license = "MIT"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,4 +12,6 @@ pub struct Args {
     pub git_ignored: bool,
     #[arg(short, long)]
     pub copy: bool,
+    #[arg(short, long)]
+    pub prefix: Option<String>,
 }

--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -86,7 +86,7 @@ impl FileTree {
         children
     }
 
-    pub fn print(&self, spacer: &str) {
+    pub fn print(&self, spacer: &str, prefix: &str) {
         let indent = spacer.repeat(self.depth);
         let name = self.path.file_name().unwrap().to_string_lossy();
         let suffix = if self.path.is_dir() { "/" } else { "" };
@@ -96,41 +96,49 @@ impl FileTree {
             false => Color::BrightCyan,
         };
 
-        println!("{}- {}{}", indent, name.color(color), suffix.color(color));
+        println!(
+            "{}{}{}{}",
+            indent,
+            prefix,
+            name.color(color),
+            suffix.color(color)
+        );
 
         for child in &self.children {
-            child.print(spacer);
+            child.print(spacer, prefix);
         }
     }
 
-    pub fn copy(&self, spacer: &str) {
+    pub fn copy(&self, spacer: &str, prefix: &str) {
         let mut output = String::new();
-        self.build_string(&mut output, spacer);
+        self.build_string(&mut output, spacer, prefix);
         let mut ctx: ClipboardContext = ClipboardProvider::new().unwrap();
         ctx.set_contents(output).unwrap();
     }
 
-    fn build_string(&self, output: &mut String, spacer: &str) {
+    fn build_string(&self, output: &mut String, spacer: &str, prefix: &str) {
         let indent = spacer.repeat(self.depth);
         let name = self.path.file_name().unwrap().to_string_lossy();
         let suffix = if self.path.is_dir() { "/" } else { "" };
 
-        let line = format!("{}- {}{}", indent, name, suffix);
+        let line = format!("{}{}{}{}", indent, prefix, name, suffix);
         output.push_str(&line);
         output.push('\n');
 
         for child in &self.children {
-            child.build_string(output, spacer);
+            child.build_string(output, spacer, prefix);
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::fs::{self, File};
     use std::io::Write;
+
     use tempfile::tempdir;
+
+    use super::*;
 
     fn create_test_environment() -> (PathBuf, HashSet<String>) {
         let test_dir = tempdir().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ fn main() {
     let path = Path::new(&dir_str);
 
     let spacer = args.spacer.unwrap_or_else(|| "    ".to_string());
+    let prefix = args.prefix.unwrap_or_else(|| "- ".to_string());
 
     if !path.exists() {
         eprintln!("No such file or directory");
@@ -31,8 +32,8 @@ fn main() {
     let file_tree = FileTree::new(path, 1, ignore, args.include_hidden, args.git_ignored);
 
     if args.copy {
-        file_tree.copy(&spacer);
+        file_tree.copy(&spacer, &prefix);
     } else {
-        file_tree.print(&spacer);
+        file_tree.print(&spacer, &prefix);
     }
 }


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # Pull Request Description
> 
> ## TL;DR
> This pull request introduces a new feature to the `dirt-r-ee` package, allowing users to specify a prefix when printing or copying the file tree. The version of the package has been updated to `0.2.0` to reflect this new feature.
> 
> ## What changed
> The main changes are in `src/cli.rs`, `src/file_tree.rs`, and `src/main.rs`. 
> 
> In `src/cli.rs`, a new argument `prefix` has been added to the `Args` struct. This allows users to specify a prefix when running the command.
> 
> In `src/file_tree.rs`, the `print` and `copy` methods of the `FileTree` struct have been updated to include a `prefix` parameter. This prefix is then used when printing or copying the file tree. The `build_string` method has also been updated in a similar way.
> 
> In `src/main.rs`, the `prefix` argument is retrieved from the command line arguments and passed to the `print` and `copy` methods.
> 
> ## How to test
> To test this change, you can run the `dirt-r-ee` command with the new `--prefix` option and a string argument. For example:
> 
> ```
> dirt-r-ee --prefix ">> "
> ```
> 
> This should print the file tree with ">> " before each file or directory name.
> 
> ## Why make this change
> This change allows users to customize the output of the `dirt-r-ee` command, making it more flexible and adaptable to different use cases. It also improves the user experience by allowing users to specify a prefix that suits their preferences or needs.
</details>