### PR TITLE
Add --out-file flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "dirt-r-ee"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "clipboard",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,4 +14,6 @@ pub struct Args {
     pub copy: bool,
     #[arg(short, long)]
     pub prefix: Option<String>,
+    #[arg(short, long)]
+    pub out_file: Option<String>,
 }

--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -116,6 +116,12 @@ impl FileTree {
         ctx.set_contents(output).unwrap();
     }
 
+    pub fn write_to_file(&self, out_file: String, spacer: &str, prefix: &str) {
+        let mut output = String::new();
+        self.build_string(&mut output, spacer, prefix);
+        std::fs::write(out_file, output).unwrap();
+    }
+
     fn build_string(&self, output: &mut String, spacer: &str, prefix: &str) {
         let indent = spacer.repeat(self.depth);
         let name = self.path.file_name().unwrap().to_string_lossy();

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,4 +36,8 @@ fn main() {
     } else {
         file_tree.print(&spacer, &prefix);
     }
+
+    if args.out_file.is_some() {
+        file_tree.write_to_file(args.out_file.unwrap(), &spacer, &prefix);
+    }
 }


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request updates the `dirt-r-ee` package from version `0.1.0` to `0.2.0` and adds a new feature that allows users to write the output to a file.
> 
> ## What changed
> - The `dirt-r-ee` package version was updated in `Cargo.lock`.
> - A new argument `out_file` was added to the `Args` struct in `cli.rs`.
> - A new method `write_to_file` was added to the `FileTree` struct in `file_tree.rs`. This method writes the output to a file.
> - The `main.rs` file was updated to call the `write_to_file` method if the `out_file` argument is provided.
> 
> ## How to test
> 1. Pull the changes from this PR.
> 2. Run the program with the `--out_file` argument followed by the name of the file you want to write to. For example: `cargo run -- --out_file output.txt`.
> 3. Check that a file with the specified name was created in the current directory and that it contains the expected output.
> 
> ## Why make this change
> This change allows users to write the output to a file, which can be useful for further processing or for storing the output for later reference. This makes the tool more flexible and useful for a wider range of use cases.
</details>