### PR TITLE
Add Homebrew installation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ including hidden files, respecting `.gitignore` rules, customizable spacing, and
 
 ## Installation
 
+You can compile dirt(r)ee on your own architecture using `cargo install`, or with Homebrew on an M1 Macbook (Intel based
+Macs might work - I haven't tried. Let me know if you do!)
+
+More installation options coming soon!
+
+### Homebrew (MacOS - M1)
+
+```bash
+brew tap calthejuggler/dirtee
+brew install dirtee
+```
+
+### Cargo Install
+
 To install Dirt-r-ee, you need Rust and Cargo installed on your system. If you don't have them installed, you can follow
 the instructions [here](https://doc.rust-lang.org/cargo/getting-started/installation.html) to install them.
 


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # Pull Request Description
> 
> ## TL;DR
> This pull request updates the README.md file to include new installation instructions for the Dirt-r-ee project. It adds instructions for compiling the project using `cargo install` and for installing it on an M1 Macbook using Homebrew.
> 
> ## What changed
> The README.md file was updated to include new installation instructions. The changes are as follows:
> 
> - Added a section on how to compile Dirt-r-ee using `cargo install`.
> - Added a section on how to install Dirt-r-ee on an M1 Macbook using Homebrew.
> 
> ## How to test
> To test these changes, follow the new installation instructions in the README.md file. Ensure that the project can be installed and runs as expected using both `cargo install` and Homebrew on an M1 Macbook.
> 
> ## Why make this change
> These changes were made to provide users with more options for installing the Dirt-r-ee project. This will make the project more accessible to users with different system configurations.
</details>